### PR TITLE
Use requests session

### DIFF
--- a/resumable/core.py
+++ b/resumable/core.py
@@ -1,13 +1,13 @@
 import os
 from enum import Enum
 import uuid
-from collections import defaultdict
 import mimetypes
 
 import requests
 
 from resumable.file import LazyLoadChunkableFile
 from resumable.worker import ResumableWorkerPool
+from resumable.util import CallbackMixin
 
 
 MB = 1024 * 1024
@@ -17,26 +17,6 @@ class ResumableSignal(Enum):
     CHUNK_COMPLETED = 0
     FILE_ADDED = 1
     FILE_COMPLETED = 2
-
-
-class CallbackMixin(object):
-
-    def __init__(self, *args, **kwargs):
-        super(CallbackMixin, self).__init__(*args, **kwargs)
-        self.signal_callbacks = defaultdict(list)
-        self.signal_proxy_targets = []
-
-    def register_callback(self, signal, callback):
-        self.signal_callbacks[signal].append(callback)
-
-    def proxy_signals_to(self, target):
-        self.signal_proxy_targets.append(target)
-
-    def send_signal(self, signal):
-        for callback in self.signal_callbacks[signal]:
-            callback()
-        for target in self.signal_proxy_targets:
-            target.send_signal(signal)
 
 
 class Resumable(CallbackMixin):

--- a/resumable/util.py
+++ b/resumable/util.py
@@ -1,3 +1,26 @@
+from collections import defaultdict
+
+
+class CallbackMixin(object):
+
+    def __init__(self, *args, **kwargs):
+        super(CallbackMixin, self).__init__(*args, **kwargs)
+        self.signal_callbacks = defaultdict(list)
+        self.signal_proxy_targets = []
+
+    def register_callback(self, signal, callback):
+        self.signal_callbacks[signal].append(callback)
+
+    def proxy_signals_to(self, target):
+        self.signal_proxy_targets.append(target)
+
+    def send_signal(self, signal):
+        for callback in self.signal_callbacks[signal]:
+            callback()
+        for target in self.signal_proxy_targets:
+            target.send_signal(signal)
+
+
 class FixedUrlSession(object):
     """A simple wrapper for requests.Session that fixes the URL."""
 

--- a/resumable/util.py
+++ b/resumable/util.py
@@ -1,0 +1,12 @@
+class FixedUrlSession(object):
+    """A simple wrapper for requests.Session that fixes the URL."""
+
+    def __init__(self, session, url):
+        self.session = session
+        self.url = url
+
+    def get(self, *args, **kwargs):
+        return self.session.get(self.url, *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self.session.post(self.url, *args, **kwargs)

--- a/tests/test_callback_mixin.py
+++ b/tests/test_callback_mixin.py
@@ -1,6 +1,7 @@
 from mock import Mock, MagicMock
 
-from resumable.core import CallbackMixin, ResumableSignal
+from resumable.util import CallbackMixin
+from resumable.core import ResumableSignal
 
 
 def test_register_callback():

--- a/tests/test_fixed_url_session.py
+++ b/tests/test_fixed_url_session.py
@@ -1,0 +1,21 @@
+from mock import MagicMock
+import requests
+
+from resumable.util import FixedUrlSession
+
+
+MOCK_URL = 'https://example.com/endpoint'
+
+
+def test_get():
+    mock_session = MagicMock(requests.Session)
+    wrapped = FixedUrlSession(mock_session, MOCK_URL)
+    assert wrapped.get(foo='bar') == mock_session.get.return_value
+    mock_session.get.assert_called_once_with(MOCK_URL, foo='bar')
+
+
+def test_post():
+    mock_session = MagicMock(requests.Session)
+    wrapped = FixedUrlSession(mock_session, MOCK_URL)
+    assert wrapped.post(foo='bar') == mock_session.post.return_value
+    mock_session.post.assert_called_once_with(MOCK_URL, foo='bar')

--- a/tests/test_resumable.py
+++ b/tests/test_resumable.py
@@ -96,6 +96,7 @@ def test_chunks(session_mock, worker_pool_mock):
 
 
 def test_next_task(mocker, session_mock, worker_pool_mock):
+    fixed_url_session_mock = mocker.patch('resumable.core.FixedUrlSession')
     mock_chunks = [
         Mock(state=ResumableChunkState.DONE),
         Mock(state=ResumableChunkState.POPPED),
@@ -107,5 +108,8 @@ def test_next_task(mocker, session_mock, worker_pool_mock):
     manager = Resumable(MOCK_TARGET)
     assert manager.next_task() == mock_chunks[3].create_task.return_value
     mock_chunks[3].create_task.assert_called_once_with(
-        manager.session, manager.target
+        fixed_url_session_mock.return_value
+    )
+    fixed_url_session_mock.assert_called_once_with(
+        session_mock.return_value, MOCK_TARGET
     )

--- a/tests/test_resumable_chunk.py
+++ b/tests/test_resumable_chunk.py
@@ -3,6 +3,7 @@ import requests
 import pytest
 
 from resumable.core import ResumableChunk, ResumableChunkState, ResumableSignal
+from resumable.util import FixedUrlSession
 
 
 def test_query():
@@ -22,19 +23,18 @@ def test_query():
     (200, ResumableChunkState.DONE)
 ])
 def test_test(get_response_code, expected_state):
-    mock_session = MagicMock(requests.Session)
+    mock_session = MagicMock(FixedUrlSession)
     mock_session.get.return_value = Mock(requests.Response,
                                          status_code=get_response_code)
-    mock_target = 'https://example.com/upload'
     mock_query = {'query': 'foo'}
     mock_send_signal = MagicMock()
 
     with patch.multiple(ResumableChunk, query=mock_query,
                         send_signal=mock_send_signal):
         chunk = ResumableChunk(Mock(), Mock())
-        chunk.test(mock_session, mock_target)
+        chunk.test(mock_session)
 
-    mock_session.get.assert_called_once_with(mock_target, data=mock_query)
+    mock_session.get.assert_called_once_with(data=mock_query)
     assert chunk.state == expected_state
     if expected_state == ResumableChunkState.DONE:
         mock_send_signal.assert_called_once_with(
@@ -43,9 +43,8 @@ def test_test(get_response_code, expected_state):
 
 
 def test_send():
-    mock_session = MagicMock(requests.Session)
+    mock_session = MagicMock(FixedUrlSession)
     mock_session.post.return_value = Mock(requests.Response)
-    mock_target = 'https://example.com/upload'
     mock_query = {'query': 'foo'}
     mock_data = b'data'
     mock_send_signal = MagicMock()
@@ -53,15 +52,13 @@ def test_send():
     with patch.multiple(ResumableChunk, query=mock_query,
                         send_signal=mock_send_signal):
         chunk = ResumableChunk(Mock(), Mock(data=mock_data))
-        chunk.send(mock_session, mock_target)
+        chunk.send(mock_session)
 
     mock_session.post.assert_called_once_with(
-        mock_target, data=mock_query, files={'file': mock_data}
+        data=mock_query, files={'file': mock_data}
     )
     assert chunk.state == ResumableChunkState.DONE
-    mock_send_signal.assert_called_once_with(
-        ResumableSignal.CHUNK_COMPLETED
-    )
+    mock_send_signal.assert_called_once_with(ResumableSignal.CHUNK_COMPLETED)
 
 
 @pytest.mark.parametrize('state, should_send', [
@@ -70,33 +67,31 @@ def test_send():
     (ResumableChunkState.DONE, False)
 ])
 def test_send_if_not_done(state, should_send):
-    mock_session = Mock(requests.Session)
-    mock_target = 'https://example.com/upload'
+    mock_session = Mock(FixedUrlSession)
     mock_send = MagicMock()
 
     with patch.multiple(ResumableChunk, send=mock_send):
         chunk = ResumableChunk(Mock(), Mock())
         chunk.state = state
-        chunk.send_if_not_done(mock_session, mock_target)
+        chunk.send_if_not_done(mock_session)
 
     if should_send:
-        mock_send.assert_called_once_with(mock_session, mock_target)
+        mock_send.assert_called_once_with(mock_session)
     else:
         mock_send.assert_not_called()
 
 
 def test_create_task():
-    mock_session = Mock(requests.Session)
-    mock_target = 'https://example.com/upload'
+    mock_session = Mock(FixedUrlSession)
     mock_test = MagicMock()
     mock_send_if_not_done = MagicMock()
 
     with patch.multiple(ResumableChunk, test=mock_test,
                         send_if_not_done=mock_send_if_not_done):
         chunk = ResumableChunk(Mock(), Mock())
-        task = chunk.create_task(mock_session, mock_target)
+        task = chunk.create_task(mock_session)
         assert chunk.state == ResumableChunkState.POPPED
         task()
 
-    mock_test.assert_called_once_with(mock_session, mock_target)
-    mock_send_if_not_done.assert_called_once_with(mock_session, mock_target)
+    mock_test.assert_called_once_with(mock_session)
+    mock_send_if_not_done.assert_called_once_with(mock_session)

--- a/tests/test_resumable_chunk.py
+++ b/tests/test_resumable_chunk.py
@@ -22,24 +22,19 @@ def test_query():
     (200, ResumableChunkState.DONE)
 ])
 def test_test(get_response_code, expected_state):
+    mock_session = MagicMock(requests.Session)
+    mock_session.get.return_value = Mock(requests.Response,
+                                         status_code=get_response_code)
     mock_target = 'https://example.com/upload'
     mock_query = {'query': 'foo'}
-    mock_headers = {'header': 'bar'}
     mock_send_signal = MagicMock()
-
-    requests_get_mock = MagicMock(
-        return_value=Mock(requests.Response, status_code=get_response_code)
-    )
 
     with patch.multiple(ResumableChunk, query=mock_query,
                         send_signal=mock_send_signal):
         chunk = ResumableChunk(Mock(), Mock())
-        with patch('requests.get', requests_get_mock):
-            chunk.test(mock_target, mock_headers)
+        chunk.test(mock_session, mock_target)
 
-    requests_get_mock.assert_called_once_with(
-        mock_target, headers=mock_headers, data=mock_query
-    )
+    mock_session.get.assert_called_once_with(mock_target, data=mock_query)
     assert chunk.state == expected_state
     if expected_state == ResumableChunkState.DONE:
         mock_send_signal.assert_called_once_with(
@@ -48,23 +43,20 @@ def test_test(get_response_code, expected_state):
 
 
 def test_send():
+    mock_session = MagicMock(requests.Session)
+    mock_session.post.return_value = Mock(requests.Response)
     mock_target = 'https://example.com/upload'
     mock_query = {'query': 'foo'}
-    mock_headers = {'header': 'bar'}
     mock_data = b'data'
     mock_send_signal = MagicMock()
-
-    requests_post_mock = MagicMock(return_value=Mock(requests.Response))
 
     with patch.multiple(ResumableChunk, query=mock_query,
                         send_signal=mock_send_signal):
         chunk = ResumableChunk(Mock(), Mock(data=mock_data))
-        with patch('requests.post', requests_post_mock):
-            chunk.send(mock_target, mock_headers)
+        chunk.send(mock_session, mock_target)
 
-    requests_post_mock.assert_called_once_with(
-        mock_target, headers=mock_headers, data=mock_query,
-        files={'file': mock_data}
+    mock_session.post.assert_called_once_with(
+        mock_target, data=mock_query, files={'file': mock_data}
     )
     assert chunk.state == ResumableChunkState.DONE
     mock_send_signal.assert_called_once_with(
@@ -78,33 +70,33 @@ def test_send():
     (ResumableChunkState.DONE, False)
 ])
 def test_send_if_not_done(state, should_send):
+    mock_session = Mock(requests.Session)
     mock_target = 'https://example.com/upload'
-    mock_headers = {'header': 'bar'}
     mock_send = MagicMock()
 
     with patch.multiple(ResumableChunk, send=mock_send):
         chunk = ResumableChunk(Mock(), Mock())
         chunk.state = state
-        chunk.send_if_not_done(mock_target, mock_headers)
+        chunk.send_if_not_done(mock_session, mock_target)
 
     if should_send:
-        mock_send.assert_called_once_with(mock_target, mock_headers)
+        mock_send.assert_called_once_with(mock_session, mock_target)
     else:
         mock_send.assert_not_called()
 
 
 def test_create_task():
+    mock_session = Mock(requests.Session)
     mock_target = 'https://example.com/upload'
-    mock_headers = {'header': 'bar'}
     mock_test = MagicMock()
     mock_send_if_not_done = MagicMock()
 
     with patch.multiple(ResumableChunk, test=mock_test,
                         send_if_not_done=mock_send_if_not_done):
         chunk = ResumableChunk(Mock(), Mock())
-        task = chunk.create_task(mock_target, mock_headers)
+        task = chunk.create_task(mock_session, mock_target)
         assert chunk.state == ResumableChunkState.POPPED
         task()
 
-    mock_test.assert_called_once()
-    mock_send_if_not_done.assert_called_once()
+    mock_test.assert_called_once_with(mock_session, mock_target)
+    mock_send_if_not_done.assert_called_once_with(mock_session, mock_target)


### PR DESCRIPTION
Persisting a requests `Session` object should provide some performance benefits, as described here:

http://docs.python-requests.org/en/master/user/advanced/#session-objects

The session object also accepts session-wide headers etc., which we are able to take advantage of to avoid passing around extra information between many parts of the application.